### PR TITLE
Add locations (Alabama, California, and Washington) to start.

### DIFF
--- a/src/vivarium_nih_us_cvd/constants/metadata.py
+++ b/src/vivarium_nih_us_cvd/constants/metadata.py
@@ -16,7 +16,9 @@ MAKE_ARTIFACT_RUNTIME = '3:00:00'
 MAKE_ARTIFACT_SLEEP = 10
 
 LOCATIONS = [
-    # TODO - project locations here
+    'Alabama',
+    'California',
+    'Washington',
 ]
 
 


### PR DESCRIPTION
Use vadmin to create the repo
The only change in this PR is to add locations.
Built an artifact for California.
Ran `simulate` on the artifact and produced results:
```
2021-05-18 16:16:47.067 | vivarium.framework.engine:report:160 - {'death_due_to_other_causes': 1,
 'person_time': 497.50855578370977,
 'total_population': 100,
 'total_population_dead': 1,
 'total_population_living': 99,
 'total_population_tracked': 100,
 'total_population_untracked': 0,
 'years_lived_with_disability': 0.0,
 'years_of_life_lost': 35.2169517900543,
 'ylls_due_to_other_causes': 35.2169517900543}
```
