### PR TITLE
Add FPG and BMI risk components. Several workarounds for data anomalies.

### DIFF
--- a/src/vivarium_nih_us_cvd/constants/data_keys.py
+++ b/src/vivarium_nih_us_cvd/constants/data_keys.py
@@ -58,7 +58,7 @@ class __IHD(NamedTuple):
 
     @property
     def log_name(self):
-        return mod.IHD_MODEL_NAME.replace('_', ' ')
+        return self.name.replace('_', ' ')
 
 
 IHD = __IHD()
@@ -84,7 +84,7 @@ class __IschemicStroke(NamedTuple):
 
     @property
     def log_name(self):
-        return mod.ISCHEMIC_STROKE_MODEL_NAME.replace('_', ' ')
+        return self.name.replace('_', ' ')
 
 
 ISCHEMIC_STROKE = __IschemicStroke()
@@ -106,7 +106,7 @@ class __HighLDLCholesterol(NamedTuple):
 
     @property
     def log_name(self):
-        return 'high ldl cholesterol'
+        return self.name.replace('_', ' ')
 
 
 LDL_C = __HighLDLCholesterol()
@@ -128,11 +128,56 @@ class __HighSystolicBloodPressure(NamedTuple):
 
     @property
     def log_name(self):
-        return 'high systolic blood pressure'
+        return self.name.replace('_', ' ')
 
 
 SBP = __HighSystolicBloodPressure()
 
+
+class __FastingPlasmaGlucose(NamedTuple):
+    DISTRIBUTION: str = 'risk_factor.high_fasting_plasma_glucose.distribution'
+    EXPOSURE_MEAN: str = 'risk_factor.high_fasting_plasma_glucose.exposure'
+    EXPOSURE_SD: str = 'risk_factor.high_fasting_plasma_glucose.exposure_standard_deviation'
+    EXPOSURE_WEIGHTS: str = 'risk_factor.high_fasting_plasma_glucose.exposure_distribution_weights'
+    RELATIVE_RISK: str = 'risk_factor.high_fasting_plasma_glucose.relative_risk'
+    PAF: str = 'risk_factor.high_fasting_plasma_glucose.population_attributable_fraction'
+    TMRED: str = 'risk_factor.high_fasting_plasma_glucose_continuous.tmred'
+    TMRED_LOCAL = 'risk_factor.high_fasting_plasma_glucose.tmred'
+    RELATIVE_RISK_SCALAR: str = 'risk_factor.high_fasting_plasma_glucose_continuous.relative_risk_scalar'
+    RELATIVE_RISK_SCALAR_LOCAL = 'risk_factor.high_fasting_plasma_glucose.relative_risk_scalar'
+
+    @property
+    def name(self):
+        return 'high_fasting_plasma_glucose'
+
+    @property
+    def log_name(self):
+        return self.name.replace('_', ' ')
+
+
+FPG = __FastingPlasmaGlucose()
+
+
+class __BMI(NamedTuple):
+    DISTRIBUTION: str = 'risk_factor.high_body_mass_index_in_adults.distribution'
+    EXPOSURE_MEAN: str = 'risk_factor.high_body_mass_index_in_adults.exposure'
+    EXPOSURE_SD: str = 'risk_factor.high_body_mass_index_in_adults.exposure_standard_deviation'
+    EXPOSURE_WEIGHTS: str = 'risk_factor.high_body_mass_index_in_adults.exposure_distribution_weights'
+    RELATIVE_RISK: str = 'risk_factor.high_body_mass_index_in_adults.relative_risk'
+    PAF: str = 'risk_factor.high_body_mass_index_in_adults.population_attributable_fraction'
+    TMRED: str = 'risk_factor.high_body_mass_index_in_adults.tmred'
+    RELATIVE_RISK_SCALAR: str = 'risk_factor.high_body_mass_index_in_adults.relative_risk_scalar'
+
+    @property
+    def name(self):
+        return 'high_body_mass_index_in_adults'
+
+    @property
+    def log_name(self):
+        return self.name.replace('_', ' ')
+
+
+BMI = __BMI()
 
 
 MAKE_ARTIFACT_KEY_GROUPS = [
@@ -141,4 +186,6 @@ MAKE_ARTIFACT_KEY_GROUPS = [
     ISCHEMIC_STROKE,
     LDL_C,
     SBP,
+    BMI,
+    FPG,
 ]

--- a/src/vivarium_nih_us_cvd/data/loader.py
+++ b/src/vivarium_nih_us_cvd/data/loader.py
@@ -105,6 +105,24 @@ def get_data(lookup_key: str, location: str) -> pd.DataFrame:
         data_keys.SBP.PAF: load_standard_data,
         data_keys.SBP.TMRED: load_metadata,
         data_keys.SBP.RELATIVE_RISK_SCALAR: load_metadata,
+
+        data_keys.FPG.DISTRIBUTION: load_metadata_mapped,
+        data_keys.FPG.EXPOSURE_MEAN: load_standard_data,
+        data_keys.FPG.EXPOSURE_SD: load_standard_data,
+        data_keys.FPG.EXPOSURE_WEIGHTS: load_standard_data,
+        data_keys.FPG.RELATIVE_RISK: load_standard_data,
+        data_keys.FPG.PAF: load_standard_data,
+        data_keys.FPG.TMRED: load_metadata,
+        data_keys.FPG.RELATIVE_RISK_SCALAR: load_metadata,
+
+        data_keys.BMI.DISTRIBUTION: load_metadata,
+        data_keys.BMI.EXPOSURE_MEAN: load_standard_data,
+        data_keys.BMI.EXPOSURE_SD: load_standard_data,
+        data_keys.BMI.EXPOSURE_WEIGHTS: load_standard_data,
+        data_keys.BMI.RELATIVE_RISK: load_standard_data,
+        data_keys.BMI.PAF: load_standard_data,
+        data_keys.BMI.TMRED: load_metadata,
+        data_keys.BMI.RELATIVE_RISK_SCALAR: load_metadata,
     }
     return mapping[lookup_key](lookup_key, location)
 
@@ -147,6 +165,13 @@ def load_metadata(key: str, location: str):
     return entity_metadata
 
 
+def load_metadata_mapped(key: str, location: str):
+    map = {
+        data_keys.FPG.DISTRIBUTION: 'ensemble'
+    }
+    return map[key]
+
+
 def _load_em_from_meid(meid: int, measure: str, location: str):
     location_id = utility_data.get_location_id(location)
     data = gbd.get_modelable_entity_draws(meid, location_id)
@@ -158,6 +183,7 @@ def _load_em_from_meid(meid: int, measure: str, location: str):
     data = vi_utils.split_interval(data, interval_column='age', split_column_prefix='age')
     data = vi_utils.split_interval(data, interval_column='year', split_column_prefix='year')
     return vi_utils.sort_hierarchical_data(data).droplevel('location')
+
 
 #
 # project-specific data functions here
@@ -317,9 +343,16 @@ def handle_special_cases(artifact: Artifact, location: str):
         data_keys.LDL_C.RELATIVE_RISK,
         data_keys.LDL_C.PAF,
         data_keys.SBP.RELATIVE_RISK,
-        data_keys.SBP.PAF
+        data_keys.SBP.PAF,
+        data_keys.BMI.RELATIVE_RISK,
+        data_keys.BMI.PAF,
+        data_keys.FPG.RELATIVE_RISK,
+        data_keys.FPG.PAF,
     ]:
         modify_rr_affected_entity(artifact, key, map)
+
+    artifact.write(data_keys.FPG.TMRED_LOCAL, artifact.load(data_keys.FPG.TMRED))
+    artifact.write(data_keys.FPG.RELATIVE_RISK_SCALAR_LOCAL, artifact.load(data_keys.FPG.RELATIVE_RISK_SCALAR))
 
 
 def get_entity(key: str):


### PR DESCRIPTION
Artifacts build and test simulation runs. Several of the "sanity checks" in vivarium inputs were disabled to allow data to be retrieved.

Info from Central Comp:
_Catherine Chen commented:
Kjell Swedin these four causes are custom aggregates we added at the very end of GBD 2019 for reporting purposes. Because they were added rather quickly and were only used for reporting they never got restrictions assigned to them. I discussed with Caitlyn and we will add restrictions based on the children causes. I will let you know when the 2019 and 2020 hierarchies have been updated with this metadata._
