### PR TITLE
Add high ldl and high sbp risks to the heart failure model

### DIFF
--- a/src/vivarium_nih_us_cvd/data/loader.py
+++ b/src/vivarium_nih_us_cvd/data/loader.py
@@ -410,7 +410,7 @@ def handle_special_cases(artifact: Artifact, location: str):
 
     # Need to make RR data match causes in the model
     map = {
-        'ischemic_heart_disease': ['acute_myocardial_infarction', 'post_myocardial_infarction_to_acute_myocardial_infarction'],
+        'ischemic_heart_disease': ['acute_myocardial_infarction', 'post_myocardial_infarction_to_acute_myocardial_infarction', 'heart_failure_from_ihd'],
         models.ISCHEMIC_STROKE_MODEL_NAME: ['acute_ischemic_stroke', 'chronic_ischemic_stroke_to_acute_ischemic_stroke'],
     }
     for key in [

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -8,11 +8,13 @@ components:
             - SI("heart_failure_from_ihd")
         risks:
             - Risk('risk_factor.high_ldl_cholesterol')
+            - RiskEffect('risk_factor.high_ldl_cholesterol', 'cause.heart_failure_from_ihd.incidence_rate')
             - RiskEffect('risk_factor.high_ldl_cholesterol', 'cause.acute_myocardial_infarction.incidence_rate')
             - RiskEffect('risk_factor.high_ldl_cholesterol', 'cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate')
             - RiskEffect('risk_factor.high_ldl_cholesterol', 'cause.acute_ischemic_stroke.incidence_rate')
             - RiskEffect('risk_factor.high_ldl_cholesterol', 'cause.chronic_ischemic_stroke_to_acute_ischemic_stroke.transition_rate')
             - Risk('risk_factor.high_systolic_blood_pressure')
+            - RiskEffect('risk_factor.high_systolic_blood_pressure', 'cause.heart_failure_from_ihd.incidence_rate')
             - RiskEffect('risk_factor.high_systolic_blood_pressure', 'cause.acute_myocardial_infarction.incidence_rate')
             - RiskEffect('risk_factor.high_systolic_blood_pressure', 'cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate')
             - RiskEffect('risk_factor.high_systolic_blood_pressure', 'cause.acute_ischemic_stroke.incidence_rate')

--- a/src/vivarium_nih_us_cvd/tools/make_artifacts.py
+++ b/src/vivarium_nih_us_cvd/tools/make_artifacts.py
@@ -185,6 +185,7 @@ def build_single_location_artifact(path: Union[str, Path], location: str, log_to
             logger.info(f'   - Loading and writing {key} data')
             builder.load_and_write_data(artifact, key, location)
             
+    logger.info(f'Running special case handler... -- {location}')
     handle_special_cases(artifact, location)
 
     logger.info(f'**Done building -- {location}**')


### PR DESCRIPTION
Two changes to make this work:

1.) Add the boilerplate code to the model spec file.
2.) Ensure that the RR "affected_entity" data has matching entries for "heart_failure_from_ihd"

simulate runs and generates results