### PR TITLE
Correct scenario column name for results processing

### DIFF
--- a/src/vivarium_nih_us_cvd/constants/results.py
+++ b/src/vivarium_nih_us_cvd/constants/results.py
@@ -14,7 +14,7 @@ TOTAL_YLLS_COLUMN = 'years_of_life_lost'
 # Columns from parallel runs
 INPUT_DRAW_COLUMN = 'input_draw'
 RANDOM_SEED_COLUMN = 'random_seed'
-OUTPUT_SCENARIO_COLUMN = 'baseline'
+OUTPUT_SCENARIO_COLUMN = 'branch_name.scenario'
 
 STANDARD_COLUMNS = {
     'total_population': TOTAL_POPULATION_COLUMN,


### PR DESCRIPTION
This change corrects the scenario column name to allow `make_results` to work.

Tested with a parallel run + `make_results`.